### PR TITLE
Default to DELETE_CASCADE, like django pre-2.0

### DIFF
--- a/wagtail_svgmap/mixins.py
+++ b/wagtail_svgmap/mixins.py
@@ -21,7 +21,7 @@ class LinkFields(models.Model):
         blank=True,
         related_name='+',
         verbose_name=_('linked page'),
-        on_delete=models.DELETE_CASCADE,
+        on_delete=models.CASCADE,
     )
     link_document = models.ForeignKey(
         'wagtaildocs.Document',
@@ -29,7 +29,7 @@ class LinkFields(models.Model):
         blank=True,
         related_name='+',
         verbose_name=_('linked document'),
-        on_delete=models.DELETE_CASCADE,
+        on_delete=models.CASCADE,
     )
 
     @property

--- a/wagtail_svgmap/mixins.py
+++ b/wagtail_svgmap/mixins.py
@@ -21,7 +21,7 @@ class LinkFields(models.Model):
         blank=True,
         related_name='+',
         verbose_name=_('linked page'),
-        on_delete=models.SET_NULL,
+        on_delete=models.DELETE_CASCADE,
     )
     link_document = models.ForeignKey(
         'wagtaildocs.Document',
@@ -29,7 +29,7 @@ class LinkFields(models.Model):
         blank=True,
         related_name='+',
         verbose_name=_('linked document'),
-        on_delete=models.SET_NULL,
+        on_delete=models.DELETE_CASCADE,
     )
 
     @property

--- a/wagtail_svgmap/models.py
+++ b/wagtail_svgmap/models.py
@@ -167,7 +167,7 @@ class Region(LinkFields, models.Model):
     Child model to specify the link target for a given element in a given image map.
     """
 
-    image_map = models.ForeignKey(to=ImageMap, related_name='regions', on_delete=models.SET_NULL)
+    image_map = models.ForeignKey(to=ImageMap, related_name='regions', on_delete=models.CASCADE)
     element_id = models.CharField(verbose_name=_('element ID'), max_length=64)
     target = models.CharField(
         verbose_name=_('link target'), blank=True, max_length=64,


### PR DESCRIPTION
Looks like I made a booboo in my initial wagtail 2 patch.

Django pre 2.0 model behaviour is equivalent to DELETE_CASCADE not SET_NULL

Use CASCADE instead of NULL.